### PR TITLE
feat(Browser): Adds browser support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,16 @@ node_js:
   - 6.0.0
   - 6
   - 7
+addons:
+  firefox: "latest"
 
 before_script:
   - npm install --dev
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 script:
   - npm test
+
+secure: "C/nhSFLipisvngls53qDq/2CHTLFBGmlVfepiBK07dkjtvT41bknDiGjoAKpOs+FUHW1DTmlDivQZbzaXtnp1r8uN4JKjaLkLhpim9R6RkiXrVLxA43ar0fJjeYggVXCxAMPCtB3Wl/Y2mRN8QhNUaSrQHd5+CDJgxds45LPe84="

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const SAUCE_TIMEOUT = 240000;
+
+module.exports = function buildKarmeConf(config) {
+  const baseConfig = {
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['browserify', 'mocha'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'src/**/*.js',
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'src/**/*.js': ['browserify'],
+    },
+
+    browserify: {
+      debug: false,
+    },
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity,
+  };
+
+  if(
+    (!process.env.SAUCE_USERNAME) ||
+    (
+      process.env.TRAVIS_PULL_REQUEST &&
+      'false' !== process.env.TRAVIS_PULL_REQUEST
+    )
+  ) {
+    config.set(Object.assign(
+      {},
+      baseConfig,
+      {
+        // test results reporter to use
+        // possible values: 'dots', 'progress'
+        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ['progress'],
+
+        // start these browsers
+        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+        browsers: ['Firefox']
+          .concat(
+            'true' === process.env.TRAVIS ?
+            [] :
+            ['Chrome']
+          ),
+      }
+    ));
+    return;
+  }
+
+  // Browsers to run on Sauce Labs
+  const customLaunchers = {
+    SL_Chrome: {
+      base: 'SauceLabs',
+      browserName: 'chrome',
+    },
+    SL_Firefox: {
+      base: 'SauceLabs',
+      browserName: 'firefox',
+    },
+    SL_IEEdge: {
+      base: 'SauceLabs',
+      browserName: 'microsoftedge',
+      version: null,
+      platform: 'Windows 10',
+    },
+  };
+
+  config.set(Object.assign(
+    {},
+    baseConfig,
+    {
+      reporters: ['dots', 'saucelabs'],
+      customLaunchers: customLaunchers,
+
+      // Increase timeouts to prevent the issue with disconnected tests (https://goo.gl/nstA69)
+      captureTimeout: SAUCE_TIMEOUT,
+      browserDisconnectTimeout: 10000,
+      browserDisconnectTolerance: 1,
+      browserNoActivityTimeout: SAUCE_TIMEOUT,
+
+      // SauceLabs config
+      sauceLabs: {
+        recordScreenshots: false,
+        connectOptions: {
+          port: 5757,
+          logfile: 'sauce_connect.log',
+        },
+        public: 'public',
+      },
+
+
+      // start these browsers
+      // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+      browsers: Object.keys(customLaunchers),
+    }
+  ));
+};

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "It helps to know why you got an error.",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha tests/*.mocha.js",
-    "coveralls": "istanbul cover _mocha --report lcovonly -- tests/*.mocha.js -R spec -t 5000 && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
-    "cover": "istanbul cover --report html _mocha -- tests/*.mocha.js -R spec -t 5000",
+    "test": "mocha src/*.mocha.js && karma start karma.conf.js",
+    "coveralls": "istanbul cover _mocha --report lcovonly -- src/*.mocha.js -R spec -t 5000 && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
+    "cover": "istanbul cover --report html _mocha -- src/*.mocha.js -R spec -t 5000",
     "cli": "env NPM_RUN_CLI=1",
-    "lint": "eslint src/index.js tests/index.mocha.js",
+    "lint": "eslint src/*.js",
     "preversion": "npm run lint && npm test"
   },
   "engines": {
@@ -29,10 +29,17 @@
     "url": "https://github.com/SimpliField/yerror/issues"
   },
   "devDependencies": {
+    "browserify": "^14.4.0",
     "coveralls": "~2.11.2",
     "eslint": "^3.4.0",
     "eslint-config-simplifield": "^4.1.1",
     "istanbul": "^0.4.2",
+    "karma": "^1.7.0",
+    "karma-browserify": "^5.1.1",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.0.1",
+    "karma-mocha": "^1.3.0",
+    "karma-sauce-launcher": "^1.1.0",
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,9 @@ class YError extends Error {
     this.wrappedErrors = wrappedErrors;
     this.name = this.toString();
 
-    Error.captureStackTrace(this, this.constructor);
+    if(Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 
   toString() {

--- a/src/index.mocha.js
+++ b/src/index.mocha.js
@@ -46,15 +46,17 @@ describe('YError', () => {
       assert.equal(err.wrappedErrors.length, 1);
       assert.deepEqual(err.params, ['This is an error!']);
 
-      assert(
-        -1 !== err.stack.indexOf('Error: This is an error!'),
-        'Stack contains original error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_UNEXPECTED (This is an error!)'),
-        'Stack contains cast error.'
-      );
-      assert.equal(err.name, err.toString());
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('Error: This is an error!'),
+          'Stack contains original error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_UNEXPECTED (This is an error!)'),
+          'Stack contains cast error.'
+        );
+        assert.equal(err.name, err.toString());
+      }
     });
 
     it('Should work with standard errors and an error code', () => {
@@ -63,14 +65,17 @@ describe('YError', () => {
       assert.equal(err.code, 'E_ERROR');
       assert.equal(err.wrappedErrors.length, 1);
       assert.deepEqual(err.params, []);
-      assert(
-        -1 !== err.stack.indexOf('Error: E_ERROR'),
-        'Stack contains original error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR ()'),
-        'Stack contains cast error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('Error: E_ERROR'),
+          'Stack contains original error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR ()'),
+          'Stack contains cast error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 
@@ -80,14 +85,17 @@ describe('YError', () => {
       assert.equal(err.code, 'E_ERROR_2');
       assert.equal(err.wrappedErrors.length, 1);
       assert.deepEqual(err.params, ['arg1', 'arg2']);
-      assert(
-        -1 !== err.stack.indexOf('Error: E_ERROR'),
-        'Stack contains first error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR_2 (arg1, arg2)'),
-        'Stack contains second error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('Error: E_ERROR'),
+          'Stack contains first error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR_2 (arg1, arg2)'),
+          'Stack contains second error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 
@@ -107,18 +115,21 @@ describe('YError', () => {
       assert.equal(err.code, 'E_ERROR_3');
       assert.equal(err.wrappedErrors.length, 2);
       assert.deepEqual(err.params, ['arg3.1', 'arg3.2']);
-      assert(
-        -1 !== err.stack.indexOf('Error: E_ERROR_1'),
-        'Stack contains first error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR_2 (arg2.1, arg2.2)'),
-        'Stack contains second error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR_3 (arg3.1, arg3.2)'),
-        'Stack contains second error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('Error: E_ERROR_1'),
+          'Stack contains first error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR_2 (arg2.1, arg2.2)'),
+          'Stack contains second error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR_3 (arg3.1, arg3.2)'),
+          'Stack contains second error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 
@@ -132,14 +143,17 @@ describe('YError', () => {
       assert.equal(err.code, 'E_UNEXPECTED');
       assert.equal(err.wrappedErrors.length, 1);
       assert.deepEqual(err.params, ['This is an error!']);
-      assert(
-        -1 !== err.stack.indexOf('Error: This is an error!'),
-        'Stack contains original error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_UNEXPECTED (This is an error!)'),
-        'Stack contains cast error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('Error: This is an error!'),
+          'Stack contains original error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_UNEXPECTED (This is an error!)'),
+          'Stack contains cast error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 
@@ -148,10 +162,13 @@ describe('YError', () => {
 
       assert.equal(err.code, 'E_ERROR');
       assert.deepEqual(err.params, ['arg1', 'arg2']);
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR (arg1, arg2)'),
-        'Stack contains cast error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR (arg1, arg2)'),
+          'Stack contains cast error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 
@@ -165,14 +182,17 @@ describe('YError', () => {
       assert.equal(err.code, 'E_UNEXPECTED');
       assert.equal(err.wrappedErrors.length, 1);
       assert.deepEqual(err.params, ['This is an error!']);
-      assert(
-        -1 !== err.stack.indexOf('Error: This is an error!'),
-        'Stack contains original error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_UNEXPECTED (This is an error!)'),
-        'Stack contains bumped error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('Error: This is an error!'),
+          'Stack contains original error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_UNEXPECTED (This is an error!)'),
+          'Stack contains bumped error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 
@@ -184,14 +204,17 @@ describe('YError', () => {
 
       assert.equal(err.code, 'E_ERROR');
       assert.deepEqual(err.params, ['arg1.1', 'arg1.2']);
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR (arg1.1, arg1.2)'),
-        'Stack contains original error.'
-      );
-      assert(
-        -1 !== err.stack.indexOf('YError: E_ERROR (arg1.1, arg1.2)'),
-        'Stack contains bumped error.'
-      );
+
+      if(Error.captureStackTrace) {
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR (arg1.1, arg1.2)'),
+          'Stack contains original error.'
+        );
+        assert(
+          -1 !== err.stack.indexOf('YError: E_ERROR (arg1.1, arg1.2)'),
+          'Stack contains bumped error.'
+        );
+      }
       assert.equal(err.name, err.toString());
     });
 


### PR DESCRIPTION
The `captureStackTrace` method is very specific to the v8 engine. Most other browsers were failing due to it.
This commit makes it work everywhere at the cost of a degraded experience on other browsers: stack trace are way less useful. That said, as most people are using Chrome for dev, the module still have interest even for frontend dev.

Would be could to find a more universal way to print the usual YError stack trace but I think the only solution is to create a custom method (`printStack()` for example.